### PR TITLE
test: add return statement test

### DIFF
--- a/src/test/java/interpreter/ast/statement/ReturnStatementTest.java
+++ b/src/test/java/interpreter/ast/statement/ReturnStatementTest.java
@@ -29,7 +29,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testConstructorWithTokenAndValue() {
+    void shouldCreateReturnStatementWithTokenAndValue() {
         // Act
         ReturnStatement returnStatement = new ReturnStatement(token, value);
 
@@ -39,7 +39,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testConstructorWithTokenOnly() {
+    void shouldCreateReturnStatementWithTokenOnly() {
         // Act
         ReturnStatement returnStatement = new ReturnStatement(token);
 
@@ -49,7 +49,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testDefaultConstructor() {
+    void shouldCreateDefaultReturnStatement() {
         // Act
         ReturnStatement returnStatement = new ReturnStatement();
 
@@ -59,7 +59,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testSetToken() {
+    void shouldSetTokenSuccessfully() {
         // Arrange
         ReturnStatement returnStatement = new ReturnStatement();
 
@@ -71,7 +71,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testSetValue() {
+    void shouldSetValueSuccessfully() {
         // Arrange
         ReturnStatement returnStatement = new ReturnStatement();
 
@@ -83,7 +83,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testLiteral() {
+    void shouldReturnLiteralFromToken() {
         // Act
         when(token.literal()).thenReturn("return");
         ReturnStatement returnStatement = new ReturnStatement(token);
@@ -93,7 +93,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testToStringWithTokenAndValue() {
+    void shouldReturnStringRepresentationWithTokenAndValue() {
         // Arrange
         when(token.literal()).thenReturn("return");
         when(value.toString()).thenReturn("MockExpression");
@@ -108,7 +108,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testToStringWithTokenOnly() {
+    void shouldReturnStringRepresentationWithTokenOnly() {
         // Act
         when(token.literal()).thenReturn("return");
         ReturnStatement returnStatement = new ReturnStatement(token);
@@ -119,7 +119,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testToStringWithNoTokenOrValue() {
+    void shouldReturnStringRepresentationWithNoTokenOrValue() {
         // Act
         ReturnStatement returnStatement = new ReturnStatement();
 
@@ -129,7 +129,7 @@ class ReturnStatementTest {
     }
 
     @Test
-    void testToStringWithValueOnly() {
+    void shouldReturnStringRepresentationWithValueOnly() {
     // Arrange
     when(value.toString()).thenReturn("MockExpression");
 

--- a/src/test/java/interpreter/ast/statement/ReturnStatementTest.java
+++ b/src/test/java/interpreter/ast/statement/ReturnStatementTest.java
@@ -1,0 +1,147 @@
+package interpreter.ast.statement;
+
+import com.github.konstantinevashalomidze.interpreter.ast.expression.Expression;
+import com.github.konstantinevashalomidze.interpreter.ast.statement.ReturnStatement;
+import com.github.konstantinevashalomidze.interpreter.token.Token;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ReturnStatementTest {
+
+    private Token token;
+    private Expression value;
+
+    @BeforeEach
+    void setUp() {
+        token = mock(Token.class);
+        value = mock(Expression.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        token = null;
+        value = null;
+    }
+
+    @Test
+    void testConstructorWithTokenAndValue() {
+        // Act
+        ReturnStatement returnStatement = new ReturnStatement(token, value);
+
+        // Assert
+        assertEquals(token, returnStatement.getToken());
+        assertEquals(value, returnStatement.getValue());
+    }
+
+    @Test
+    void testConstructorWithTokenOnly() {
+        // Act
+        ReturnStatement returnStatement = new ReturnStatement(token);
+
+        // Assert
+        assertEquals(token, returnStatement.getToken());
+        assertNull(returnStatement.getValue());
+    }
+
+    @Test
+    void testDefaultConstructor() {
+        // Act
+        ReturnStatement returnStatement = new ReturnStatement();
+
+        // Assert
+        assertNull(returnStatement.getToken());
+        assertNull(returnStatement.getValue());
+    }
+
+    @Test
+    void testSetToken() {
+        // Arrange
+        ReturnStatement returnStatement = new ReturnStatement();
+
+        // Act
+        returnStatement.setToken(token);
+
+        // Assert
+        assertEquals(token, returnStatement.getToken());
+    }
+
+    @Test
+    void testSetValue() {
+        // Arrange
+        ReturnStatement returnStatement = new ReturnStatement();
+
+        // Act
+        returnStatement.setValue(value);
+
+        // Assert
+        assertEquals(value, returnStatement.getValue());
+    }
+
+    @Test
+    void testLiteral() {
+        // Act
+        when(token.literal()).thenReturn("return");
+        ReturnStatement returnStatement = new ReturnStatement(token);
+
+        // Assert
+        assertEquals("return", returnStatement.literal());
+    }
+
+    @Test
+    void testToStringWithTokenAndValue() {
+        // Arrange
+        when(token.literal()).thenReturn("return");
+        when(value.toString()).thenReturn("MockExpression");
+        ReturnStatement returnStatement = new ReturnStatement(token, value);
+
+        // Act
+        String result = returnStatement.toString();
+
+        // Assert
+        String expected = "ReturnStatement (return)\n  |- MockExpression\n";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testToStringWithTokenOnly() {
+        // Act
+        when(token.literal()).thenReturn("return");
+        ReturnStatement returnStatement = new ReturnStatement(token);
+
+        // Assert
+        String expected = "ReturnStatement (return)\n";
+        assertEquals(expected, returnStatement.toString());
+    }
+
+    @Test
+    void testToStringWithNoTokenOrValue() {
+        // Act
+        ReturnStatement returnStatement = new ReturnStatement();
+
+        // Assert
+        String expected = "ReturnStatement\n";
+        assertEquals(expected, returnStatement.toString());
+    }
+
+    @Test
+    void testToStringWithValueOnly() {
+    // Arrange
+    when(value.toString()).thenReturn("MockExpression");
+
+    ReturnStatement returnStatement = new ReturnStatement();
+    returnStatement.setValue(value); 
+
+    // Act
+    String result = returnStatement.toString();
+
+    // Assert
+    String expected = "ReturnStatement\n  |- MockExpression\n";
+    assertEquals(expected, result);
+    }
+
+}


### PR DESCRIPTION

This pull request adds a new test class to ensure the correctness and reliability of the `ReturnStatement` AST node implementation in the `interpreter.ast.statement` package.

It improves the codebase by increasing test coverage for constructors, setters, and critical methods such as `literal()` and `toString()`.

---

## Summary of implementation details

- Introduced a test class: `ReturnStatementTest.java` located at  
  `src/test/java/interpreter/ast/statement/ReturnStatementTest.java`
  
- The test suite uses **JUnit 5** and **Mockito** to mock dependencies (`Token` and `Expression`).

- Covered the following behavior:
  - **Constructor tests**:
    - `ReturnStatement(Token, Expression)`
    - `ReturnStatement(Token)`
    - `ReturnStatement()` (default constructor)
  - **Mutator methods**:
    - `setToken()`
    - `setValue()`
  - **Method behavior**:
    - `literal()` returns the token’s literal string
    - `toString()` handles:
      - Both `token` and `value` present
      - Only `token` present
      - Neither present
      - *[Edge case]* `value` present, but `token` is `null`

---

## Testing performed

- All tests run using:
  ```bash
  mvn test
  ```
- Confirmed that all tests now pass
---

## 📌 Related Issues

Fixes [#14](https://github.com/KonstantineVashalomidze/kosta-interpreter/issues/14)

---

## Note

This PR has been rebased on the latest `main` branch (SHA: da536b71fd06f2a36311174a27a90b48f74d5859).

