### PR TITLE
Fix README.md examples to align with interpreter's identifier restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ var hashmap = { 'a': 1, 'b': false, 'c': 'd', 'e': [1, 2] }; // Hashmap
 - *Grouping*: Use parentheses `()` to influence evaluation order.
 
 ```javascript
-var expression1 = 10 * (20 / 2); // Evaluates to 100
-var expression2 = !true & false | true != 5 > 7 - 1; // Evaluates to true
-var expression3 = 5 + 1 * 2 - 3 / 1 == 30; // Evaluates to false
-var expression4 = -5; // Prefix operator
-var expression5 = !true; // Prefix operator
-var expression6 = (5 > 7 == 5 < 7) != false; // Grouping and comparison
+var arithmeticExpression = 10 * (20 / 2); // Evaluates to 100
+var logicalExpression = !true & false | true != 5 > 7 - 1; // Evaluates to true
+var mixedArithmeticComparison = 5 + 1 * 2 - 3 / 1 == 30; // Evaluates to false
+var negativePrefix = -5; // Prefix operator
+var notTruePrefix = !true; // Prefix operator
+var complexComparison = (5 > 7 == 5 < 7) != false; // Grouping and comparison
 ```
 
 #### 3. **Functions**


### PR DESCRIPTION
Description:

Purpose of the changes:-
This PR updates the README.md to remove examples that use identifiers containing non-letter characters (e.g., expression1), which are not supported by the current interpreter.

Summary of implementation details:-
Replaced invalid identifiers in code examples with valid ones using only alphabetic characters (e.g., changed expression1 to arithmetic Expression).
Ensured all examples now conform to the interpreter’s parsing rules.

Testing performed:-
Manually tested the updated examples with the interpreter to confirm they work as expected.
Reviewed the README to ensure consistency throughout.

Screenshots/examples
Before:
var expression1 = 10 * (20 / 2);

After:
var arithmeticExpression = 10 * (20 / 2);


Related issues
Fixes #18