### PR TITLE
test: add unit tests for ExpressionStatement class

### DIFF
--- a/src/test/java/interpreter/ast/statement/ExpressionStatementTest.java
+++ b/src/test/java/interpreter/ast/statement/ExpressionStatementTest.java
@@ -1,0 +1,177 @@
+package interpreter.ast.statement;
+
+import com.github.konstantinevashalomidze.interpreter.ast.expression.Expression;
+import com.github.konstantinevashalomidze.interpreter.ast.statement.ExpressionStatement;
+import com.github.konstantinevashalomidze.interpreter.token.Token;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ExpressionStatementTest {
+
+    private Token token;
+    private Expression expression;
+
+    @BeforeEach
+    void setUp() {
+        token = mock(Token.class);
+        expression = mock(Expression.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        token = null;
+        expression = null;
+    }
+
+    @Test
+    void shouldCreateExpressionStatementWithTokenAndExpression() {
+        // Act
+        ExpressionStatement expressionStatement = new ExpressionStatement(token, expression);
+
+        // Assert
+        assertEquals(token, expressionStatement.getToken());
+        assertEquals(expression, expressionStatement.getExpression());
+    }
+
+    @Test
+    void shouldCreateExpressionStatementWithTokenOnly() {
+        // Act
+        ExpressionStatement expressionStatement = new ExpressionStatement(token);
+
+        // Assert
+        assertEquals(token, expressionStatement.getToken());
+        assertNull(expressionStatement.getExpression());
+    }
+
+    @Test
+    void shouldCreateDefaultReturnStatement() {
+        // Act
+        ExpressionStatement expressionStatement = new ExpressionStatement();
+
+        // Assert
+        assertNull(expressionStatement.getToken());
+        assertNull(expressionStatement.getExpression());
+    }
+
+    @Test
+    void shouldSetTokenSuccessfully() {
+        // Arrange
+        ExpressionStatement expressionStatement = new ExpressionStatement();
+
+        // Act
+        expressionStatement.setToken(token);
+
+        // Assert
+        assertEquals(token, expressionStatement.getToken());
+    }
+
+    @Test
+    void shouldSetValueSuccessfully() {
+        // Arrange
+        ExpressionStatement expressionStatement = new ExpressionStatement();
+
+        // Act
+        expressionStatement.setExpression(expression);
+
+        // Assert
+        assertEquals(expression, expressionStatement.getExpression());
+    }
+
+    @Test
+    void shouldReturnLiteralFromToken() {
+        // Act
+        when(token.literal()).thenReturn("TokenLiteralMock");
+        ExpressionStatement expressionStatement = new ExpressionStatement(token);
+
+        // Assert
+        assertEquals("TokenLiteralMock", expressionStatement.literal());
+    }
+
+    @Test
+    void shouldReturnStringRepresentationWithTokenAndExpressionNextLine() {
+        // Arrange
+        when(token.literal()).thenReturn("TokenLiteralMock");
+        when(expression.toString()).thenReturn("MockExpression\n");
+        ExpressionStatement expressionStatement = new ExpressionStatement(token, expression);
+
+        // Act
+        String result = expressionStatement.toString();
+
+        // Assert
+        String expected = "ExpressionStatement (TokenLiteralMock)\n  |- MockExpression\n  |  \n";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldReturnStringRepresentationWithTokenAndExpression() {
+        // Arrange
+        when(token.literal()).thenReturn("TokenLiteralMock");
+        when(expression.toString()).thenReturn("MockExpression");
+        ExpressionStatement expressionStatement = new ExpressionStatement(token, expression);
+
+        // Act
+        String result = expressionStatement.toString();
+
+        // Assert
+        String expected = "ExpressionStatement (TokenLiteralMock)\n  |- MockExpression\n";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldReturnStringRepresentationWithTokenOnly() {
+        // Act
+        when(token.literal()).thenReturn("TokenLiteralMock");
+        ExpressionStatement expressionStatement = new ExpressionStatement(token);
+
+        // Assert
+        String expected = "ExpressionStatement (TokenLiteralMock)\n";
+        assertEquals(expected, expressionStatement.toString());
+    }
+
+    @Test
+    void shouldReturnStringRepresentationWithNoTokenOrExpression() {
+        // Act
+        ExpressionStatement expressionStatement = new ExpressionStatement();
+
+        // Assert
+        String expected = "ExpressionStatement\n";
+        assertEquals(expected, expressionStatement.toString());
+    }
+
+    @Test
+    void shouldReturnStringRepresentationWithExpressionNextLineOnly() {
+        // Arrange
+        when(expression.toString()).thenReturn("MockExpression\n");
+
+        ExpressionStatement expressionStatement = new ExpressionStatement();
+        expressionStatement.setExpression(expression);
+
+        // Act
+        String result = expressionStatement.toString();
+
+        // Assert
+        String expected = "ExpressionStatement\n  |- MockExpression\n  |  \n";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldReturnStringRepresentationWithExpressionOnly() {
+        // Arrange
+        when(expression.toString()).thenReturn("MockExpression");
+
+        ExpressionStatement expressionStatement = new ExpressionStatement();
+        expressionStatement.setExpression(expression);
+
+        // Act
+        String result = expressionStatement.toString();
+
+        // Assert
+        String expected = "ExpressionStatement\n  |- MockExpression\n";
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
This pull request adds a new unit test class to ensure the correctness and reliability of the ExpressionStatement AST node implementation in the interpreter.ast.statement package.

It improves the codebase by increasing test coverage for constructors, setters, and critical methods such as literal() and toString().
Summary of implementation details

Introduced a test class: ExpressionStatementTest.java located at
src/test/java/interpreter/ast/statement/ExpressionStatementTest.java

The test suite uses JUnit 5 and Mockito to mock dependencies (Token and Expression).

Covered the following behavior:
* Constructor tests:
   - <code>ExpressionStatement(Token, Expression)</code>
   - <code>ExpressionStatement(Token)</code>
   - <code>ExpressionStatement() (default constructor)</code>
* Mutator methods:
   - <code>setToken()</code>
   - <code>setExpression()</code>
* Method behavior:
   - <code>literal()</code> returns the token’s literal string
   - Covers the following scenarios for <code>toString()</code>:
       + Both token and expression present
       + Only token present
       + Neither present
       + Expression is present and ends with a next line character
       + [Edge case] expression present, but token is null         

### Related Issues

Fixes #13 
### Note

This PR has been rebased on the latest main branch (SHA: 0df1c44)